### PR TITLE
Add context for build error when PCI IDs not found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = "1.19.0"
 phf = { version = "0.11.2", default-features = false, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.56.0",features = [
+windows = { version = "0.57.0",features = [
         "Win32_Devices_DeviceAndDriverInstallation", 
         "Win32_Foundation"
     ]}


### PR DESCRIPTION
I forgot to initialize the submodules, so the script failed. I figure others may do the same, so additional context may help.