### PR TITLE
Add context for build error when PCIIDs not found

### DIFF
--- a/build/parser.rs
+++ b/build/parser.rs
@@ -182,7 +182,8 @@ pub fn ingest_class_database(data: Vec<&str>) -> Map<u8> {
 }
 
 pub fn ingest_pciids(path: &Path) -> PciIdsParsed {
-    let pciids_raw = fs::read_to_string(path).unwrap();
+    let pciids_raw = fs::read_to_string(path)
+        .expect("Failed to read PCI IDs. Are the repository submodules initialized?");
     let pciids_filtered: Vec<&str> = pciids_raw
         .split(LINE_BREAK)
         .filter(|str| !clean(str).starts_with('#')) // Filter comments.


### PR DESCRIPTION
Reinitiating PR from fix-specific branch. Apologies for the noise.

I forgot to initialize the project submodules, so the build failed. I figure others may do the same, so additional context may help.